### PR TITLE
Missed two instances of c.2

### DIFF
--- a/multi-gadget.sh
+++ b/multi-gadget.sh
@@ -76,7 +76,7 @@ cd ../../class/hs
 ln -s ../../header/h
 cd ../../../../..
 
-ln -s /sys/kernel/config/usb_gadget/pi4/functions/uvc.usb0 /sys/kernel/config/usb_gadget/pi4/configs/c.2/uvc.usb0
-ln -s /sys/kernel/config/usb_gadget/pi4/functions/acm.usb0 /sys/kernel/config/usb_gadget/pi4/configs/c.2/acm.usb0
+ln -s /sys/kernel/config/usb_gadget/pi4/functions/uvc.usb0 /sys/kernel/config/usb_gadget/pi4/configs/c.1/uvc.usb0
+ln -s /sys/kernel/config/usb_gadget/pi4/functions/acm.usb0 /sys/kernel/config/usb_gadget/pi4/configs/c.1/acm.usb0
 udevadm settle -t 5 || :
 ls /sys/class/udc > /sys/kernel/config/usb_gadget/pi4/UDC


### PR DESCRIPTION
My search and replace failed me. There were a total of six instances of c.2 that needed to be replaced with c.1. My earlier change only caught the first four. This change amends that last two as well...